### PR TITLE
this could be useful :B

### DIFF
--- a/.mgit/bundle.sh
+++ b/.mgit/bundle.sh
@@ -235,7 +235,13 @@ compile_version_info() {
 	[ $OS = mingw ] || return
 	sayt versioninfo "$VERSIONINFO"
 	s="$(echo '
-	1 VERSIONINFO
+	1 VERSIONINFO'
+	if [ "${#FILEVERSION}" = 7 ]; then
+		echo "
+		FILEVERSION ${FILEVERSION//./,}
+		PRODUCTVERSION ${FILEVERSION//./,}"
+	fi
+	echo '
 	{
 		BLOCK "StringFileInfo" {
 			BLOCK "040904b0" {'
@@ -494,6 +500,7 @@ usage() {
 	echo "  -i  --icon FILE.ico                Set icon (Windows)"
 	echo "  -i  --icon FILE.png                Set icon (OSX; requires -w)"
 	echo "  -vi --versioninfo \"Name=Val;...\"   Set VERSIONINFO fields (Windows)"
+	echo "  -fv --fileversion 				   Set FILEVERSION field (Windows)"
 	echo "  -av --appversion VERSION|auto      Set bundle.appversion to VERSION"
 	echo "  -ar --apprepo REPO                 Git repo for -av auto"
 	echo
@@ -590,6 +597,8 @@ parse_opts() {
 				NOCONSOLE=1;;
 			-vi | --versioninfo)
 				VERSIONINFO="$VERSIONINFO;$1"; shift;;
+			-fv | --fileversion)
+				FILEVERSION="$1"; shift;;
 			-av  | --appversion)
 				APPVERSION="$1"; shift;;
 			-ar  | --apprepo)

--- a/.mgit/bundle.sh
+++ b/.mgit/bundle.sh
@@ -236,15 +236,19 @@ compile_version_info() {
 	sayt versioninfo "$VERSIONINFO"
 	s="$(echo '
 	1 VERSIONINFO
-		{
+	{
 		BLOCK "StringFileInfo" {
 			BLOCK "040904b0" {'
 			while read -d';' -r pair; do
+				[ -z "$pair" ] && continue
 				IFS='=' read -r key val <<<"$pair"
 				echo "				VALUE \"$key\", \"$val\000\""
 			done <<<"$1;"
 	echo '			}
 		}
+		BLOCK "VarFileInfo" {
+	        VALUE "Translation", 0x409, 1200
+	    }
 	}
 	')" o=$ODIR/_versioninfo.res.o compile_resource
 }

--- a/.mgit/bundle.sh
+++ b/.mgit/bundle.sh
@@ -358,6 +358,7 @@ link_mingw() {
 		-Wl,--export-all-symbols \
 		-Wl,--whole-archive `aopt "$ALIBS"` \
 		-Wl,--no-whole-archive \
+		-Wl,--allow-multiple-definition \
 		`lopt "$DLIBS"` $xopt
 }
 
@@ -370,6 +371,7 @@ link_linux() {
 		-pthread \
 		-Wl,--whole-archive `aopt "$ALIBS"` \
 		-Wl,--no-whole-archive `lopt "$DLIBS"` \
+		-Wl,--allow-multiple-definition \
 		-Wl,-rpath,'\$\$ORIGIN'
 	chmod +x "$EXE"
 }


### PR DESCRIPTION
**Changes to bundle.sh:**

- Added **--allow-multiple-definition** to linker flags
- Prevent the creation of empty keys in the **StringFileInfo** block of the windows resource file.

![image](https://user-images.githubusercontent.com/39842292/87914689-a3995080-ca36-11ea-8573-b02ddafc67b1.png)

- Added a parameter to set the **FILEVERSION** statement. _Eg: -fv "1.0.0.0"_

![image](https://user-images.githubusercontent.com/39842292/87914663-9714f800-ca36-11ea-982a-ca5599174c56.png)

- Added **Translation** key in **VarFileInfo** block.

![image](https://user-images.githubusercontent.com/39842292/87915301-9af54a00-ca37-11ea-8399-9176d4ac62c0.png)